### PR TITLE
Remove suffix for fdroid

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,7 +48,6 @@ android {
     productFlavors {
         foss {
             dimension "dependencies"
-            versionNameSuffix "-foss"
         }
         google {
             dimension "dependencies"


### PR DESCRIPTION
...as you'd know it's not-google :+1: 

Also, breaks F-Droid AutoUpdate workflow for now

Ref: https://gitlab.com/fdroid/fdroidserver/-/issues/144
Ref: https://gitlab.com/fdroid/fdroidserver/-/issues/733

/LE: https://gitlab.com/fdroid/fdroiddata/-/merge_requests/7991/diffs