### PR TITLE
Make Chargepoint.power nullable

### DIFF
--- a/app/src/main/java/net/vonforst/evmap/api/availability/AvailabilityDetector.kt
+++ b/app/src/main/java/net/vonforst/evmap/api/availability/AvailabilityDetector.kt
@@ -86,7 +86,7 @@ abstract class BaseAvailabilityDetector(private val client: OkHttpClient) : Avai
                 // find corresponding powers in GE data
                 val gePowers =
                     chargepoints.filter { equivalentPlugTypes(it.type).any { it == type } }
-                        .map { it.power }.distinct().sorted()
+                        .mapNotNull { it.power }.distinct().sorted()
 
                 // if the distinct number of powers is the same, try to match.
                 if (powers.size == gePowers.size) {
@@ -131,7 +131,7 @@ data class ChargeLocationStatus(
             (connectors == null || connectors.map {
                 equivalentPlugTypes(it)
             }.any { equivalent -> it.type in equivalent })
-                    && (minPower == null || it.power > minPower)
+                    && (minPower == null || (it.power != null && it.power > minPower))
         }
         return this.copy(status = statusFiltered)
     }

--- a/app/src/main/java/net/vonforst/evmap/api/chargeprice/ChargepriceModel.kt
+++ b/app/src/main/java/net/vonforst/evmap/api/chargeprice/ChargepriceModel.kt
@@ -48,11 +48,9 @@ data class ChargepriceStation(
                 charger.coordinates.lat,
                 charger.chargepriceData.country,
                 charger.chargepriceData.network,
-                charger.chargepoints.zip(plugTypes).filter {
-                    equivalentPlugTypes(it.first.type).any { it in compatibleConnectors }
-                }.map {
-                    ChargepriceChargepoint(it.first.power, it.second)
-                }
+                charger.chargepoints.zip(plugTypes)
+                    .filter { equivalentPlugTypes(it.first.type).any { it in compatibleConnectors } }
+                    .map { ChargepriceChargepoint(it.first.power ?: 0.0, it.second) }
             )
         }
     }

--- a/app/src/main/java/net/vonforst/evmap/api/openchargemap/OpenChargeMapModel.kt
+++ b/app/src/main/java/net/vonforst/evmap/api/openchargemap/OpenChargeMapModel.kt
@@ -141,7 +141,7 @@ data class OCMConnection(
 ) {
     fun convert(refData: OCMReferenceData) = Chargepoint(
         convertConnectionTypeFromOCM(connectionTypeId, refData),
-        power ?: 0.0,
+        power,
         quantity ?: 1
     )
 

--- a/app/src/main/java/net/vonforst/evmap/ui/MarkerUtils.kt
+++ b/app/src/main/java/net/vonforst/evmap/ui/MarkerUtils.kt
@@ -13,12 +13,16 @@ import kotlin.math.max
 fun getMarkerTint(
     charger: ChargeLocation,
     connectors: Set<String>? = null
-): Int = when {
-    charger.maxPower(connectors) >= 100 -> R.color.charger_100kw
-    charger.maxPower(connectors) >= 43 -> R.color.charger_43kw
-    charger.maxPower(connectors) >= 20 -> R.color.charger_20kw
-    charger.maxPower(connectors) >= 11 -> R.color.charger_11kw
-    else -> R.color.charger_low
+): Int {
+    val maxPower = charger.maxPower(connectors)
+    return when {
+        maxPower == null -> R.color.charger_low
+        maxPower >= 100 -> R.color.charger_100kw
+        maxPower >= 43 -> R.color.charger_43kw
+        maxPower >= 20 -> R.color.charger_20kw
+        maxPower >= 11 -> R.color.charger_11kw
+        else -> R.color.charger_low
+    }
 }
 
 class MarkerAnimator(val gen: ChargerIconGenerator) {

--- a/app/src/main/res/layout/item_connector.xml
+++ b/app/src/main/res/layout/item_connector.xml
@@ -4,7 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
-
         <import type="net.vonforst.evmap.adapter.ConnectorAdapter.ChargepointWithAvailability" />
         <import type="net.vonforst.evmap.ui.BindingAdaptersKt" />
 
@@ -74,6 +73,7 @@
             android:layout_marginBottom="8dp"
             android:text="@{item.chargepoint.formatPower()}"
             android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+            app:goneUnless="@{item.chargepoint.hasKnownPower()}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Not all data sources provide power for all connectors (e.g. OpenChargeMap and OpenStreetMap don't always). Even without the power level, knowing what connectors there are is still useful.

Commit is extracted from the OSM implementation. I reverted the filter for ChargePrice and instead used a fallback to 0.0.