### PR TITLE
Remove some non-determinism

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -276,6 +276,7 @@ aboutLibraries {
         "Bouncy Castle Licence",  // bcprov
         "CDDL + GPLv2 with classpath exception",  // javax.annotation-api
     )
+    excludeFields = arrayOf("generated")
     strictMode = com.mikepenz.aboutlibraries.plugin.StrictMode.FAIL
 }
 


### PR DESCRIPTION
Your app is not built reproducible in F-Droid, but we continuously test older versions on https://verification.f-droid.org/ and would like more and more apps to become repro

Looking at the latest app report: https://verification.f-droid.org/packages/net.vonforst.evmap/ we can fix it by disabling the generated entry, or upgrading the lib to 11.5.0 or later.

ref: https://github.com/mikepenz/AboutLibraries/issues/784#issuecomment-1205501876

ref: https://github.com/mikepenz/AboutLibraries/releases/tag/11.5.0