### PR TITLE
Auto: Show total chargepoints even if availability is missing

### DIFF
--- a/app/src/main/java/net/vonforst/evmap/auto/ChargerListFormatter.kt
+++ b/app/src/main/java/net/vonforst/evmap/auto/ChargerListFormatter.kt
@@ -25,6 +25,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.IconCompat
 import net.vonforst.evmap.R
 import net.vonforst.evmap.api.availability.ChargeLocationStatus
+import net.vonforst.evmap.api.availability.ChargepointStatus
 import net.vonforst.evmap.model.ChargeLocation
 import net.vonforst.evmap.model.FILTERS_FAVORITES
 import net.vonforst.evmap.ui.ChargerIconGenerator
@@ -182,18 +183,18 @@ class ChargerListFormatter(
             }
 
             // availability
+            val total = charger.chargepoints.sumOf { it.count }
+            var status = List(total) { ChargepointStatus.UNKNOWN }
             availabilities[charger.id]?.second?.let { av ->
-                val status = av.status.values.flatten()
-                val available = availabilityText(status)
-                val total = charger.chargepoints.sumOf { it.count }
-
-                if (text.isNotEmpty()) text.append(" · ")
-                text.append(
-                    "$available/$total",
-                    ForegroundCarColorSpan.create(carAvailabilityColor(status)),
-                    Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
-                )
+                status = av.status.values.flatten()
             }
+            val available = availabilityText(status)
+            if (text.isNotEmpty()) text.append(" · ")
+            text.append(
+                "$available/$total",
+                ForegroundCarColorSpan.create(carAvailabilityColor(status)),
+                Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+            )
 
             addText(text)
             setMetadata(


### PR DESCRIPTION
I don't know if this works, it's untested.

The problem I'm trying to solve is that in Android Auto only nearby chargers **with** availability data show the number of chargepoints. I would like to always see the total number of chargepoints since locations with many chargepoints are more likely to have a free slot than locations with few chargepoints.