### PR TITLE
Auto: Sort nearby locations by distance in meters

### DIFF
--- a/app/src/main/java/net/vonforst/evmap/storage/ChargeLocationsDao.kt
+++ b/app/src/main/java/net/vonforst/evmap/storage/ChargeLocationsDao.kt
@@ -101,7 +101,7 @@ abstract class ChargeLocationsDao {
     ): List<ChargeLocation>
 
     @SkipQueryVerification
-    @Query("SELECT * FROM chargelocation WHERE dataSource == :dataSource AND PtDistWithin(coordinates, MakePoint(:lng, :lat, 4326), :radius) AND timeRetrieved > :after AND ROWID IN (SELECT ROWID FROM SpatialIndex WHERE f_table_name = 'ChargeLocation' AND f_geometry_column = 'coordinates' AND search_frame = BuildCircleMbr(:lng, :lat, :radius)) ORDER BY Distance(coordinates, MakePoint(:lng, :lat, 4326))")
+    @Query("SELECT * FROM chargelocation WHERE dataSource == :dataSource AND PtDistWithin(coordinates, MakePoint(:lng, :lat, 4326), :radius) AND timeRetrieved > :after AND ROWID IN (SELECT ROWID FROM SpatialIndex WHERE f_table_name = 'ChargeLocation' AND f_geometry_column = 'coordinates' AND search_frame = BuildCircleMbr(:lng, :lat, :radius)) ORDER BY Distance(coordinates, MakePoint(:lng, :lat, 4326), 0)")
     abstract suspend fun getChargeLocationsRadius(
         lat: Double,
         lng: Double,
@@ -583,7 +583,7 @@ class ChargeLocationsRepository(
         val region =
             radiusSpatialIndexQuery(location, radius)
         val order =
-            "ORDER BY Distance(coordinates, MakePoint(${location.longitude}, ${location.latitude}, 4326))"
+            "ORDER BY Distance(coordinates, MakePoint(${location.longitude}, ${location.latitude}, 4326), 0)"
         return queryWithFilters(api, filters, region, order)
     }
 


### PR DESCRIPTION
The return value of Distance() differs depending on which version of that's used:

Distance( geom1 Geometry , geom2 Geometry ) : Double precision
  return the distance between geom1 and geom2 (always measured in CRS units).

Distance( geom1 Geometry , geom2 Geometry ,
          use_ellipsoid Boolean ) : Double precision
  return the distance between geom1 and geom2 (measured in meters).

Fixes #411