### PR TITLE
Nobil: Run cache cleanup job more frequently

### DIFF
--- a/app/src/main/java/net/vonforst/evmap/api/nobil/NobilApi.kt
+++ b/app/src/main/java/net/vonforst/evmap/api/nobil/NobilApi.kt
@@ -115,7 +115,7 @@ class NobilApiWrapper(
     override val id = "nobil"
     override val supportsOnlineQueries = false // Online queries are supported, but can't be used together with full downloads
     override val supportsFullDownload = true
-    override val cacheLimit = Duration.ofDays(300L)
+    override val cacheLimit = Duration.ofDays(15L)
     val api = NobilApi.create(baseurl, context)
 
     override suspend fun fullDownload(): FullDownloadResult<NobilReferenceData> {


### PR DESCRIPTION
This helps EVMap keep up-to-date with the frequent changes to the Nobil database. Chargers removed by Nobil will now be removed quicker from EVMap.
