### PR TITLE
Fix app crash when downloading full charger list from data source

### DIFF
--- a/app/src/main/java/net/vonforst/evmap/fragment/MapFragment.kt
+++ b/app/src/main/java/net/vonforst/evmap/fragment/MapFragment.kt
@@ -654,7 +654,7 @@ class MapFragment : Fragment(), OnMapReadyCallback, MenuProvider {
         binding.progressBar2.isIndeterminate = res.progress == null
         binding.progressBar2.progress = ((res.progress ?: 0f) * 100f).toInt().coerceIn(0, 100)
         binding.search.hint = if (res.progress != null) {
-            getString(R.string.downloading_chargers_percent, (res.progress * 100f).toInt())
+            getString(R.string.downloading_chargers_percent, (res.progress * 100f))
         } else {
             getString(R.string.search)
         }


### PR DESCRIPTION
R.string.downloading_chargers_percent expects a Float argument, but an Int was supplied.