### PR TITLE
Limit download progress percentage to range 0-100

### DIFF
--- a/app/src/main/java/net/vonforst/evmap/fragment/MapFragment.kt
+++ b/app/src/main/java/net/vonforst/evmap/fragment/MapFragment.kt
@@ -654,7 +654,7 @@ class MapFragment : Fragment(), OnMapReadyCallback, MenuProvider {
         binding.progressBar2.isIndeterminate = res.progress == null
         binding.progressBar2.progress = ((res.progress ?: 0f) * 100f).toInt().coerceIn(0, 100)
         binding.search.hint = if (res.progress != null) {
-            getString(R.string.downloading_chargers_percent, (res.progress * 100f))
+            getString(R.string.downloading_chargers_percent, (res.progress * 100f).coerceIn(0f, 100f))
         } else {
             getString(R.string.search)
         }


### PR DESCRIPTION
For nobil the percentage reaches 101. I haven't figured out why nobil's data is out of sync.

When querying nobil for the total number of chargers we get:
```
Norway: 4957
Sweden: 9108
------------
       14065
```
.. but the data dump we download has:
```
Norway: 5168
Sweden: 9059
------------
       14227
```

----

Could be fixed in the nobil data source instead if that's more appropriate..
Eg:
```
--- a/app/src/main/java/net/vonforst/evmap/api/nobil/NobilApi.kt
+++ b/app/src/main/java/net/vonforst/evmap/api/nobil/NobilApi.kt
@@ -348,7 +348,7 @@ class NobilFullDownloadResult(private val data: NobilDynamicResponseData,
             }
         }
     override val progress: Float
-        get() = downloadProgress
+        get() = min(1.0, downloadProgress)
     override val referenceData: NobilReferenceData
         get() = refData ?: throw UnsupportedOperationException("referenceData is only available once download is complete")
 }
```